### PR TITLE
Fix focus loss when setting fullscreen

### DIFF
--- a/transmission-daemon@patapon.info/extension.js
+++ b/transmission-daemon@patapon.info/extension.js
@@ -1373,7 +1373,6 @@ var TorrentsTopControls = GObject.registerClass({
     }
 
     hideAddEntry() {
-        transmissionDaemonIndicator.menu.actor.grab_key_focus();
         this.add_entry.text = "";
         this.add_entry.remove_style_pseudo_class('error');
         this.add_entry.remove_style_pseudo_class('inactive');


### PR DESCRIPTION
If this extension is running, when a window changes to fullscreen mode, it loses the focus. This is very inconvenient when playing a movie: when the user sets fullscreen, (s)he has to do an extra click on the movie to give to the player the focus, and be able to control it from the keyboard.

This patch fixes it.