### PR TITLE
Full support for Gnome Shell 3.38 and 40

### DIFF
--- a/transmission-daemon@patapon.info/extension.js
+++ b/transmission-daemon@patapon.info/extension.js
@@ -1188,6 +1188,8 @@ var TorrentName = GObject.registerClass({
         this.box = new St.BoxLayout({
             vertical: false,
             style_class: 'torrent-controls',
+            x_expand: true,
+            x_align: Clutter.ActorAlign.END,
         });
 
         let name_label = new St.Label({
@@ -1196,7 +1198,7 @@ var TorrentName = GObject.registerClass({
         });
 
         this.add(name_label);
-        this.add(this.box, { expand: true, x_fill: false, x_align: St.Align.END, });
+        this.add(this.box);
 
         this.updateButtons();
     }
@@ -1257,30 +1259,32 @@ var TorrentsControls = GObject.registerClass({
         this.vbox = new St.BoxLayout({
             vertical: true,
             style_class: 'torrents-controls-vbox',
+            x_expand: true,
         });
 
-        this.ctrl_box = new St.BoxLayout({ vertical: false, });
+        this.ctrl_box = new St.BoxLayout({
+             vertical: false,
+             x_expand: true,
+        });
 
         this.ctrl_btns = new St.BoxLayout({
             vertical: false,
             style_class: 'torrents-controls-btn',
         });
+
         this.ctrl_info = new St.Label({
             style_class: 'torrents-controls-text',
             text: '',
+            x_expand: true,
+            x_align: Clutter.ActorAlign.END,
         });
 
         this.ctrl_box.add(this.ctrl_btns);
-        this.ctrl_box.add(this.ctrl_info, {
-            expand: true,
-            x_fill: false,
-            y_fill: false,
-            x_align: St.Align.END,
-        });
+        this.ctrl_box.add(this.ctrl_info);
 
-        this.vbox.add(this.ctrl_box, { expand: true, span: -1, });
+        this.vbox.add(this.ctrl_box);
 
-        this.add(this.vbox, { expand: true, span: -1, });
+        this.add(this.vbox);
     }
 
     setInfo(text) {
@@ -1341,23 +1345,25 @@ var TorrentsTopControls = GObject.registerClass({
         this.add_box = new St.BoxLayout({
             vertical: false,
             style_class: 'torrents-add',
+            x_expand: true,
         });
         this.add_box_btn = false;
         this.add_entry = new St.Entry({
             style_class: 'add-entry',
             hint_text: _("Torrent URL or Magnet link"),
             can_focus: true,
+            x_expand: true,
         });
         this.add_btn = new ControlButton("object-select", "",
                                          this.torrentAdd.bind(this));
         this.add_box.hide();
 
-        this.add_box.add(this.add_entry, { expand: true, });
+        this.add_box.add(this.add_entry);
         this.add_box.add(this.add_btn.actor);
 
         this.ctrl_info.text = _("Connecting...");
 
-        this.vbox.add(this.add_box, { expand: true, span: -1, });
+        this.vbox.add(this.add_box);
     }
 
     toggleAddEntry(button) {

--- a/transmission-daemon@patapon.info/metadata.json
+++ b/transmission-daemon@patapon.info/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.34"],
+    "shell-version": ["3.38", "40"],
     "uuid": "transmission-daemon@patapon.info",
     "name": "Transmission Daemon Indicator",
     "url": "https://github.com/thekevjames/gnome-shell-extension-transmission-daemon",


### PR DESCRIPTION
Added the patch by squall77it

https://github.com/TheKevJames/gnome-shell-extension-transmission-daemon/pull/22

which adds compatibility with Gnome Shell 3.38. Also added "40" in metadata.json.